### PR TITLE
Updated guest, host, rpc, types to make it run in a TypeScript environment. Alla test still pass.

### DIFF
--- a/src/guest.ts
+++ b/src/guest.ts
@@ -1,6 +1,6 @@
 import { extractMethods, isWorker } from "./helpers";
 import { registerLocalMethods, registerRemoteMethods } from "./rpc";
-import { actions, events, ISchema } from "./types";
+import { actions, events, IConnection, ISchema } from "./types";
 
 const REQUEST_INTERVAL = 600;
 const TIMEOUT_INTERVAL = 3000;
@@ -8,7 +8,7 @@ const TIMEOUT_INTERVAL = 3000;
 let interval: any = null;
 let connected = false;
 
-function connect(schema: ISchema = {}, options: any = {}) {
+function connect(schema: ISchema = {}, options: any = {}): Promise<IConnection> {
   return new Promise((resolve, reject) => {
 
     const localMethods = extractMethods(schema);

--- a/src/host.ts
+++ b/src/host.ts
@@ -2,7 +2,7 @@ import short from "short-uuid";
 
 import { extractMethods, getOriginFromURL } from "./helpers";
 import { registerLocalMethods, registerRemoteMethods } from "./rpc";
-import { actions, events, IConnections, ISchema } from "./types";
+import { actions, events, IConnections, IConnection, ISchema } from "./types";
 
 const connections: IConnections = {};
 
@@ -24,7 +24,7 @@ function isValidTarget(iframe: HTMLIFrameElement, event: any) {
  * @param options
  * @returns Promise
  */
-function connect(guest: HTMLIFrameElement | Worker, schema: ISchema = {}, options?: any) {
+function connect(guest: HTMLIFrameElement | Worker, schema: ISchema = {}, options?: any): Promise<IConnection> {
   if (!guest) throw new Error("a target is required");
 
   // this check should be improved
@@ -68,7 +68,7 @@ function connect(guest: HTMLIFrameElement | Worker, schema: ISchema = {}, option
       };
 
       // resolve connection object
-      const connection = { remote, close };
+      const connection: IConnection = { remote, close };
       connections[connectionID] = connection;
       return resolve(connection);
     }
@@ -77,6 +77,8 @@ function connect(guest: HTMLIFrameElement | Worker, schema: ISchema = {}, option
     listeners.addEventListener(events.MESSAGE, handleHandshake);
   });
 }
+
+
 
 export default ({
   connect,

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -33,7 +33,7 @@ export function registerLocalMethods(
       if (callName !== methodName) return;
       if (connectionID !== _connectionID) return;
 
-      const payload = {
+      const payload: IRPCResolvePayload = {
         action: actions.RPC_RESOLVE,
         callID,
         callName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,11 @@ export interface ISchema {
   [prop: string]: any;
 }
 
+export interface IConnection {
+  remote: ISchema;
+  close: () => void;
+}
+
 export interface IConnections {
   [connectionID: string]: ISchema;
 }
@@ -48,8 +53,8 @@ export interface IRPCRequestPayload {
 
 export interface IRPCResolvePayload {
   action: actions.RPC_RESOLVE | actions.RPC_REJECT;
-  result?: any;
-  error?: Error;
+  result?: any | null;
+  error?: Error | null;
   callID: string;
   callName: string;
   connectionID: string;


### PR DESCRIPTION
I was using the library in a "typescript": "^3.8.2" project. It was failing to compile due to some missing types declared.
I changed some definitions to make it works.
The only drawbak is "esModuleInterop": true, need to be set in tsconfig.json due to ("short-uuid": "^3.1.1") import type (import short from "short-uuid";) in host.ts