### PR TITLE
Fixed a small bug in browser environment. In some browsers event.source is not valued.

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -138,7 +138,7 @@ export function createRPC(
 
       if (guest) guest.postMessage(payload);
       else if (isWorker()) (self as any).postMessage(payload);
-      else event.source.postMessage(payload, event.origin);
+      else (event.source || event.target).postMessage(payload, event.origin);
     });
   };
 }

--- a/tests/integrations/rimless.min.js
+++ b/tests/integrations/rimless.min.js
@@ -8,8 +8,9 @@ var REQUEST_INTERVAL = 600;
 var TIMEOUT_INTERVAL = 3000;
 var interval = null;
 var connected = false;
-function connect(schema) {
+function connect(schema, options) {
     if (schema === void 0) { schema = {}; }
+    if (options === void 0) { options = {}; }
     return new Promise(function (resolve, reject) {
         var localMethods = helpers_1.extractMethods(schema);
         // on handshake response


### PR DESCRIPTION
I needed this little change to make rimless work in an Angular 9 application. I was wandering is this can be integrated directly in the library.

Thank you