### PR TITLE
Fix falsy `payload.result` values

### DIFF
--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -23,7 +23,7 @@ export function registerLocalMethods(
   schema: ISchema = {},
   methods: any[] = [],
   _connectionID: string,
-  guest?: Worker,
+  guest?: Worker
 ): any {
   const listeners: any[] = [];
   methods.forEach((methodName) => {
@@ -49,7 +49,14 @@ export function registerLocalMethods(
       // run function and return the results to the remote
       try {
         const result = await get(schema, methodName)(...args);
-        payload.result = JSON.parse(JSON.stringify(result || {}));
+
+        if (!result) {
+          // if the result is falsy (null, undefined, "", etc), set it directly
+          payload.result = result;
+        } else {
+          // otherwise parse a stringified version of it
+          payload.result = JSON.parse(JSON.stringify(result));
+        }
       } catch (error) {
         payload.action = actions.RPC_REJECT;
         payload.error = JSON.parse(JSON.stringify(error, Object.getOwnPropertyNames(error)));
@@ -90,7 +97,7 @@ export function createRPC(
   _connectionID: string,
   event: any,
   listeners: Array<() => void> = [],
-  guest?: Worker,
+  guest?: Worker
 ) {
   return (...args: any) => {
     return new Promise((resolve, reject) => {
@@ -149,7 +156,7 @@ export function registerRemoteMethods(
   methods: any[] = [],
   _connectionID: string,
   event: any,
-  guest?: Worker,
+  guest?: Worker
 ) {
   const remote = { ...schema };
   const listeners: Array<() => void> = [];


### PR DESCRIPTION
In testing, I noticed that returning void (or other falsy values) resulted in rimless constructing an empty object in `payload.result` (see logged object):

<img width="865" alt="image" src="https://github.com/user-attachments/assets/d31be8a6-e7a7-457f-a504-07c818eb5f81" />

With this change, we now return falsy payload results directly, without JSON-stringifying-then-parsing:

<img width="866" alt="image" src="https://github.com/user-attachments/assets/c3b6cc29-de1a-4e47-bef1-50a9e250ccfb" />