### PR TITLE
Add transferables support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -159,27 +159,33 @@ export function getTargetHost(): any {
  * @param target The target to send the message to
  * @param message The message to send
  * @param origin Optional origin for iframe communication
+ * @param transferables Optional transferables for postMessage
  */
-export function postMessageToTarget(target: Target, message: any, origin?: string): void {
+export function postMessageToTarget(
+  target: Target,
+  message: any,
+  origin?: string,
+  transferables?: Transferable[],
+): void {
   if (!target) {
     throw new Error("Rimless Error: No target specified for postMessage");
   }
 
   // Node.js Worker
   if (isNodeEnv() && target === parentPort) {
-    target.postMessage(JSON.parse(JSON.stringify(message)));
+    target.postMessage(message, { transfer: transferables });
     return;
   }
 
   // Web Worker
   if (isWorker()) {
-    target.postMessage(JSON.parse(JSON.stringify(message)));
+    target.postMessage(message, { transfer: transferables });
     return;
   }
 
   // iframe or window
   if (target.postMessage) {
-    target.postMessage(JSON.parse(JSON.stringify(message)), { targetOrigin: origin || "*" });
+    target.postMessage(message, { targetOrigin: origin || "*", transfer: transferables });
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import guest from "./guest";
 import host from "./host";
+import { withTransferable } from "./rpc";
 
-export { host, guest };
+export { host, guest, withTransferable };
 
 export * from "./types";

--- a/tests/rpc.test.ts
+++ b/tests/rpc.test.ts
@@ -49,6 +49,7 @@ describe("registerRemoteMethods", () => {
         connectionID: "conn",
       },
       event.origin,
+      []
     );
 
     // Resolve first RPC
@@ -78,6 +79,7 @@ describe("registerRemoteMethods", () => {
         connectionID: "conn",
       },
       event.origin,
+      []
     );
 
     const handlerBar = addEventListenerSpy.mock.calls[1][2];
@@ -93,4 +95,3 @@ describe("registerRemoteMethods", () => {
     await expect(promiseBar).resolves.toBe("resultBar");
   });
 });
-


### PR DESCRIPTION
> [!IMPORTANT]
> This builds off the fix in #61.

Following up on comments in #51, this PR adds an API with which developers can mark parts of their message payloads for no-copy transfers to the other context.

@au-re — happy to document and test this further (i.e. more than just the provided JSDoc), but will look to you for guidance re: what would fit with the lib.

The POC I wrote in our app looks like:

```ts
// guest.js
host.connect({
  // ...

  // create and transfer two blobs
  testTransferable: async (callArg: string) => {
    const blob1 = new Blob(["example1"], { type: "text/plain" });
    const blob2 = new Blob(["example2"], { type: "text/plain" });

    const [arrayBuffer1, arrayBuffer2] = await Promise.all([
      blob1.arrayBuffer(),
      blob2.arrayBuffer(),
    ]);

    return withTransferable((transfer) => ({
      callArg,
      blob1: { buffer: transfer(arrayBuffer1), type: blob1.type },
      blob2: { buffer: transfer(arrayBuffer2), type: blob2.type },
    });
  },
  // receive one blob
  testReceiveTransferable(payload) {
    const {
      callArg,
      blob: { buffer, type },
    } = payload;
    console.log("returned with callArg", callArg);

    const blob = new Blob([buffer], { type });
    blob.text().then((text) => console.log("got", text));
  },
});
```

```ts
// host.js
const { callArg, blob1, blob2 } = await guest.remote.testTransferable("abc");

console.log("returned with callArg", callArg);
const blob = new Blob([blob1.buffer], { type: blob1.type });
blob.text().then((text) => console.log("got blob 1", text));

console.log("transferring back blob2");
await guest.remote.testReceiveTransferable(
  withTransferable((transfer) => ({
    callArg,
    blob: { buffer: transfer(blob2.buffer), type: blob2.type },
  })),
);
```