### PR TITLE
Fix handshake reply

### DIFF
--- a/src/guest.ts
+++ b/src/guest.ts
@@ -14,16 +14,16 @@ function connect(schema: Schema = {}, eventHandlers?: EventHandlers): Promise<Co
       if (eventData?.action !== actions.HANDSHAKE_REPLY) return;
 
       // register local methods
-      const unregisterLocal = registerLocalMethods(schema, localMethods, eventData.connectionID, listenTo, sendTo);
+      const unregisterLocal = registerLocalMethods(localMethods, eventData.connectionID, listenTo, sendTo);
 
       // register remote methods
       const { remote, unregisterRemote } = registerRemoteMethods(
         eventData.schema,
-        eventData.methods,
+        eventData.methodNames,
         eventData.connectionID,
         event,
         listenTo,
-        sendTo,
+        sendTo
       );
 
       await eventHandlers?.onConnectionSetup?.(remote);
@@ -53,8 +53,8 @@ function connect(schema: Schema = {}, eventHandlers?: EventHandlers): Promise<Co
 
     const payload = {
       action: actions.HANDSHAKE_REQUEST,
-      methods: localMethods,
-      schema: JSON.parse(JSON.stringify(schema)),
+      methodNames: Object.keys(localMethods),
+      schema: schema,
     };
 
     postMessageToTarget(sendTo, payload);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -34,7 +34,7 @@ export function isIframe() {
  * @param obj
  */
 export function extractMethods(obj: any) {
-  const paths: string[] = [];
+  const methods: Record<string, (...args: any) => any> = {};
   (function parse(obj: any, path = "") {
     Object.keys(obj).forEach((prop) => {
       const propPath = path ? `${path}.${prop}` : prop;
@@ -42,11 +42,12 @@ export function extractMethods(obj: any) {
         parse(obj[prop], propPath);
       }
       if (typeof obj[prop] === "function") {
-        paths.push(propPath);
+        methods[propPath] = obj[prop];
+        delete obj[prop];
       }
     });
   })(obj);
-  return paths;
+  return methods;
 }
 
 const urlRegex = /^(https?:|file:)?\/\/([^/:]+)?(:(\d+))?/;

--- a/src/host.ts
+++ b/src/host.ts
@@ -66,24 +66,24 @@ function connect(guest: Guest, schema: Schema = {}): Promise<Connection> {
 
       // register local methods
       const localMethods = extractMethods(schema);
-      const unregisterLocal = registerLocalMethods(schema, localMethods, connectionID, listenTo, sendTo);
+      const unregisterLocal = registerLocalMethods(localMethods, connectionID, listenTo, sendTo);
 
       // register remote methods
       const { remote, unregisterRemote } = registerRemoteMethods(
         eventData.schema,
-        eventData.methods,
+        eventData.methodNames,
         connectionID,
         event,
         listenTo,
-        sendTo,
+        sendTo
       );
 
       // send a HANDSHAKE REPLY to the guest
       const payload = {
         action: actions.HANDSHAKE_REPLY,
         connectionID,
-        schema,
-        methods: localMethods,
+        schema: schema,
+        methodNames: Object.keys(localMethods),
       };
 
       postMessageToTarget(sendTo, payload, event.origin);

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,14 +38,14 @@ export interface RimlessEvent extends EventListener {
 export interface HandshakeRequestPayload {
   action: actions.HANDSHAKE_REQUEST;
   connectionID: string;
-  methods: string[];
+  methodNames: string[];
   schema: Schema;
 }
 
 export interface HandshakeConfirmationPayload {
   action: actions.HANDSHAKE_REPLY;
   connectionID: string;
-  methods: string[];
+  methodNames: string[];
   schema: Schema;
 }
 

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -25,20 +25,45 @@ describe("extract functions", () => {
     },
   };
 
-  it("returns empty array when no functions", () => {
-    expect(extractMethods(noFunctions)).toEqual([]);
+  it("extracts and returns empty object when no functions", () => {
+    expect(extractMethods(noFunctions)).toEqual({});
   });
 
-  it("returns single function path", () => {
-    expect(extractMethods(singleFunction)).toEqual(["foo"]);
+  it("extracts and returns a single function path : fn pair", () => {
+    const { foo } = singleFunction;
+
+    expect(extractMethods(singleFunction)).toEqual({ foo });
+
+    // deletes the function from the original object
+    expect(singleFunction).toEqual({ foo: undefined });
   });
 
-  it("returns multiple function paths", () => {
-    expect(extractMethods(multipleFunctions).sort()).toEqual(["foo", "bar"].sort());
+  it("extracts and returns multiple function path : fn pairs", () => {
+    const { foo, bar } = multipleFunctions;
+
+    expect(extractMethods(multipleFunctions)).toEqual({ foo, bar });
+
+    // deletes the functions from the original object
+    expect(multipleFunctions).toEqual({ foo: undefined, bar: undefined });
   });
 
-  it("returns nested function paths", () => {
-    expect(extractMethods(nestedFunctions).sort()).toEqual(["foo.bar.baz", "foo.foo"].sort());
+  it("extracts and returns a flat object with nested function path : fn pairs", () => {
+    const {
+      foo: {
+        foo,
+        bar: { baz },
+      },
+    } = nestedFunctions;
+
+    expect(extractMethods(nestedFunctions)).toEqual({
+      "foo.bar.baz": baz,
+      "foo.foo": foo,
+    });
+
+    // deletes the functions from the original object
+    expect(nestedFunctions).toEqual({
+      foo: { bar: { baz: undefined }, foo: undefined },
+    });
   });
 
   it("handles null and undefined values", () => {
@@ -47,7 +72,12 @@ describe("extract functions", () => {
       bar: undefined,
       baz: () => {},
     };
-    expect(extractMethods(withNulls)).toEqual(["baz"]);
+    const { baz } = withNulls;
+
+    expect(extractMethods(withNulls)).toEqual({ baz });
+
+    // deletes the function from the original object
+    expect(withNulls).toEqual({ foo: null, bar: undefined, baz: undefined });
   });
 
   it("handles arrays of functions", () => {
@@ -55,7 +85,16 @@ describe("extract functions", () => {
       foo: [() => {}, () => {}],
       bar: () => {},
     };
-    expect(extractMethods(withArrays).sort()).toEqual(["foo.0", "foo.1", "bar"].sort());
+    const {
+      foo: [foo0, foo1],
+      bar,
+    } = withArrays;
+
+    expect(extractMethods(withArrays)).toEqual({
+      "foo.0": foo0,
+      "foo.1": foo1,
+      bar: bar,
+    });
   });
 });
 


### PR DESCRIPTION
@au-re I noticed while porting that a host schema was throwing when it defined functions; _this_ seems to be a case where `parse(stringify(...))` was necessary (or, at least helpful :)

Instead of relying on parse-then-stringify, I opted to actually _extract_ the methodNames during the extract step. This traded a tiny bit of complexity to the `extractMethods` handler, but I think it was worth it :)