### PR TITLE
Fix host cleanup for handshake replies

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -94,6 +94,7 @@ function connect(guest: Guest, schema: Schema = {}): Promise<Connection> {
       const close = () => {
         delete connections[connectionID];
         removeEventListener(listenTo, events.MESSAGE, handleHandshake);
+        removeEventListener(listenTo, events.MESSAGE, handleHandshakeReply);
         unregisterRemote();
         unregisterLocal();
         if (guestIsWorker) {


### PR DESCRIPTION
## Summary
- ensure `host.close` unsubscribes from the handshake reply listener

## Testing
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*