### PR TITLE
Add nested API example

### DIFF
--- a/docs/NestedAPIDemo.mdx
+++ b/docs/NestedAPIDemo.mdx
@@ -1,0 +1,25 @@
+import { Meta } from "@storybook/blocks";
+import NestedExample from "./examples/Nested/NestedExample";
+
+<Meta title="Nested API Demo" />
+
+# Nested Methods
+
+Rimless supports nested method schemas. Remote APIs can expose deeply nested
+functions and you can access them using dot notation on the `remote` object.
+
+For example, a worker may expose:
+
+```ts
+{
+  user: {
+    profile: {
+      get: () => ({ name: "Alice", age: 30 })
+    }
+  }
+}
+```
+
+You can call this from the host with `remote.user.profile.get()`.
+
+<NestedExample />

--- a/docs/examples/Nested/NestedExample.tsx
+++ b/docs/examples/Nested/NestedExample.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from "react";
+
+import { host, Connection } from "../../../src/index";
+import Worker from "./worker?worker";
+
+function NestedExample() {
+  const [profile, setProfile] = React.useState<any | null>(null);
+  const [connection, setConnection] = React.useState<Connection | null>(null);
+
+  useEffect(() => {
+    const options = { getHostMessage: () => "Hello from host" };
+    const worker = new Worker();
+    host.connect(worker, options).then(setConnection);
+  }, []);
+
+  const fetchProfile = async () => {
+    if (!connection) return;
+
+    const res = await connection.remote.user.profile.get();
+    setProfile(res);
+  };
+
+  return (
+    <div>
+      <h1>Nested API Demo</h1>
+      <button type="button" onClick={fetchProfile}>
+        load profile
+      </button>
+      {profile && <pre>{JSON.stringify(profile)}</pre>}
+    </div>
+  );
+}
+
+export default NestedExample;

--- a/docs/examples/Nested/worker.ts
+++ b/docs/examples/Nested/worker.ts
@@ -1,0 +1,27 @@
+import { guest } from "../../../src/index";
+
+const api = {
+  user: {
+    profile: {
+      async get() {
+        return { name: "Alice", age: 30 };
+      },
+    },
+  },
+};
+
+async function getHostMessageExample(remote: any) {
+  const msg = await remote.getHostMessage();
+  return `Worker received: ${msg}`;
+}
+
+const run = async () => {
+  await guest.connect(
+    { ...api, getHostMessageExample },
+    {
+      onConnectionSetup: async () => {},
+    },
+  );
+};
+
+run();


### PR DESCRIPTION
## Summary
- add NestedAPI documentation page
- demonstrate nested API usage with a worker example

## Testing
- `npm test` *(fails: vitest not found)*