### PR TITLE
Add support for sharedworker

### DIFF
--- a/src/guest.ts
+++ b/src/guest.ts
@@ -7,13 +7,13 @@ import {
   removeEventListener,
 } from "./helpers";
 import { registerLocalMethods, registerRemoteMethods } from "./rpc";
-import { actions, EventHandlers, events, Connection, Schema } from "./types";
+import { actions, GuestConnectOptions, events, Connection, Schema } from "./types";
 
-function connect(schema: Schema = {}, eventHandlers?: EventHandlers): Promise<Connection> {
+function connect(schema: Schema = {}, options?: GuestConnectOptions): Promise<Connection> {
   return new Promise(async (resolve) => {
     const localMethods = extractMethods(schema);
-    const sendTo = getTargetHost();
-    const listenTo = self || window;
+    const sendTo = options?.hostTarget ?? getTargetHost();
+    const listenTo = options?.hostTarget ?? (self || window);
 
     // on handshake response
     async function handleHandshakeResponse(event: any) {
@@ -27,13 +27,13 @@ function connect(schema: Schema = {}, eventHandlers?: EventHandlers): Promise<Co
         eventData.connectionID,
         event,
         listenTo,
-        sendTo,
+        sendTo
       );
 
       // register local methods, passing the remote object
       const unregisterLocal = registerLocalMethods(localMethods, eventData.connectionID, listenTo, sendTo, remote);
 
-      await eventHandlers?.onConnectionSetup?.(remote);
+      await options?.onConnectionSetup?.(remote);
 
       // send a HANDSHAKE REPLY to the host
       const payload = {

--- a/src/host.ts
+++ b/src/host.ts
@@ -49,14 +49,16 @@ function connect(guest: Guest, schema: Schema = {}): Promise<Connection> {
 
   const guestIsWorker = isWorkerLike(guest);
 
-  const listenTo = guestIsWorker || isNodeEnv() ? (guest as Worker) : window;
+  const listenTo =
+    guestIsWorker || isNodeEnv() ? (guest as Worker) : guest instanceof SharedWorker ? guest.port : window;
 
   return new Promise((resolve) => {
     const connectionID = generateId();
 
     // on handshake request
     function handleHandshake(event: any) {
-      const sendTo = guestIsWorker || isNodeEnv() ? (guest as Worker) : event.source;
+      const sendTo =
+        guestIsWorker || isNodeEnv() ? (guest as Worker) : guest instanceof SharedWorker ? guest.port : event.source;
 
       if (!guestIsWorker && !isNodeEnv() && !isValidTarget(guest, event)) return;
 
@@ -74,7 +76,7 @@ function connect(guest: Guest, schema: Schema = {}): Promise<Connection> {
         connectionID,
         event,
         listenTo,
-        sendTo,
+        sendTo
       );
 
       // Now register local methods, passing the remote object

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface NodeWorker {
   terminate(): void;
 }
 
+// `SharedWorker` is not `WorkerLike`, because it must be messaged through a port
 export type WorkerLike = Worker | NodeWorker;
 
 export enum events {
@@ -66,10 +67,11 @@ export interface RPCResolvePayload {
   connectionID: string;
 }
 
-export interface EventHandlers {
-  onConnectionSetup: (remote: Schema) => Promise<void>;
-}
+export type GuestConnectOptions = {
+  hostTarget?: Target;
+  onConnectionSetup?: (remote: Schema) => Promise<void>;
+};
 
-export type Guest = WorkerLike | HTMLIFrameElement;
-export type Target = Window | WorkerLike;
-export type Environment = Window | WorkerLike;
+export type Guest = WorkerLike | HTMLIFrameElement | SharedWorker;
+export type Target = Window | WorkerLike | MessagePort;
+export type Environment = Window | WorkerLike | MessagePort;


### PR DESCRIPTION
I was trying to use `rimless` to connect to a `SharedWorker`, which has different `listenTo` and `sendTo` semantics:

```ts
// in window
async function connect() {
  const worker = new SharedWorker(...);
  const connectionPromise = host.connect(worker, { ... });

  worker.port.start();
  return await connectionPromise;
}
```

```ts
// in worker
const connections = [];

self.addEventListener("connect", (event) => {
  const port = event.ports[0];
  const connectionPromise = guest.connect({ ... }, { hostTarget: port });

  port.start();
  connections.push(await connectionPromise);
});
```