### PR TITLE
Support sandboxed opaque iframe handshakes

### DIFF
--- a/.changeset/opaque-origin-iframes.md
+++ b/.changeset/opaque-origin-iframes.md
@@ -1,0 +1,5 @@
+---
+"rimless": minor
+---
+
+Support RPC handshakes with sandboxed opaque-origin iframes.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format:check": "biome check .",
     "lint": "biome lint .",
     "test": "vitest run",
+    "test:browser": "npm run build && node tests/browser/opaque-origin-iframe.mjs",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -138,6 +138,11 @@ export function getOriginFromURL(url: string | null) {
   return `${protocol}//${hostname}${portSuffix}`;
 }
 
+export function resolveTargetOrigin(origin?: string | null) {
+  if (!origin || origin === "null") return "*";
+  return origin;
+}
+
 export function get(obj: any, path: string | Array<string | number>, defaultValue?: any): any {
   const keys = Array.isArray(path) ? path : path.split(".").filter(Boolean);
   let result = obj;
@@ -227,7 +232,7 @@ export function getTargetHost(): any {
 export function postMessageToTarget(
   target: Target,
   message: any,
-  origin?: string,
+  origin?: string | null,
   transferables?: Transferable[],
 ): void {
   if (!target) {
@@ -248,7 +253,7 @@ export function postMessageToTarget(
 
   // iframe or window
   if (target.postMessage) {
-    target.postMessage(message, { targetOrigin: origin || "*", transfer: transferables });
+    target.postMessage(message, { targetOrigin: resolveTargetOrigin(origin), transfer: transferables });
     return;
   }
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -29,6 +29,13 @@ function isValidTarget(guest: Guest, event: any) {
     const childOrigin = getOriginFromURL(childURL);
     const hasProperOrigin = event.origin === childOrigin;
     const hasProperSource = event.source === iframe.contentWindow;
+    const hasOpaqueOrigin = event.origin === "null";
+    const isSandboxedOpaqueIframe =
+      hasOpaqueOrigin && iframe.hasAttribute("sandbox") && !iframe.sandbox.contains("allow-same-origin");
+
+    if (isSandboxedOpaqueIframe) {
+      return hasProperSource;
+    }
 
     // For inline iframes (srcdoc/about:blank) we can only rely on source matching
     if (hasInlineContent || childURL === "about:blank") {

--- a/tests/browser/opaque-origin-iframe.mjs
+++ b/tests/browser/opaque-origin-iframe.mjs
@@ -1,0 +1,337 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const rimlessBundle = await readFile(new URL("../../lib/rimless.min.js", import.meta.url), "utf8");
+const scriptBundle = rimlessBundle.replace(/<\/script/gi, "<\\/script");
+
+const childHtml = `<!doctype html>
+<html>
+  <body>
+    <script>${scriptBundle}</script>
+    <script>
+      (async () => {
+        parent.postMessage({ type: "child-loaded" }, "*");
+        const connection = await rimless.guest.connect({
+          guestEcho: (value) => \`guest:\${value}\`,
+        });
+        parent.postMessage({ type: "child-connected" }, "*");
+        window.addEventListener("message", async (event) => {
+          if (event.data?.type !== "call-host") return;
+
+          try {
+            const hostResult = await connection.remote.hostEcho("child");
+            parent.postMessage({ type: "child-result", value: hostResult }, "*");
+          } catch (error) {
+            parent.postMessage({ type: "child-error", message: error?.stack || String(error) }, "*");
+          }
+        });
+      })().catch((error) => {
+        parent.postMessage({ type: "child-error", message: error?.stack || String(error) }, "*");
+      });
+    </script>
+  </body>
+</html>`;
+
+const childUrl = `data:text/html;charset=utf-8,${encodeURIComponent(childHtml)}`;
+
+const parentHtml = `<!doctype html>
+<html>
+  <body>
+    <script>${scriptBundle}</script>
+    <script>
+      const childUrl = ${JSON.stringify(childUrl)};
+      const status = [];
+
+      function recordStatus(value) {
+        status.push(value);
+        document.body.dataset.status = status.join("|");
+      }
+
+      window.addEventListener("error", (event) => {
+        recordStatus(\`error:\${event.message}\`);
+      });
+
+      window.addEventListener("unhandledrejection", (event) => {
+        recordStatus(\`rejection:\${event.reason?.stack || event.reason}\`);
+      });
+
+      function createChildMessageWaiter(iframe) {
+        const waiters = new Map();
+
+        window.addEventListener("message", (event) => {
+            if (event.source !== iframe.contentWindow) return;
+
+            recordStatus(\`\${event.origin}:\${event.data?.type || event.data?.action}:\${event.data?.callName || ""}\`);
+
+            if (event.data?.type === "child-error") {
+              for (const waiter of waiters.values()) {
+                waiter.reject(new Error(event.data.message));
+              }
+              waiters.clear();
+              return;
+            }
+
+            const waiter = waiters.get(event.data?.type);
+            if (waiter) {
+              waiters.delete(event.data.type);
+              waiter.resolve(event.data.value);
+            }
+          });
+
+        return (type) =>
+          new Promise((resolve, reject) => {
+            waiters.set(type, { resolve, reject });
+          });
+      }
+
+      async function runTest() {
+        const iframe = document.createElement("iframe");
+        iframe.sandbox.add("allow-scripts");
+        iframe.src = childUrl;
+
+        recordStatus("host-connect-start");
+        const waitForChildMessage = createChildMessageWaiter(iframe);
+        const childConnectedPromise = waitForChildMessage("child-connected");
+        const childResultPromise = waitForChildMessage("child-result");
+        const hostConnectionPromise = rimless.host.connect(iframe, {
+          hostEcho: (value) => \`host:\${value}\`,
+        });
+
+        document.body.append(iframe);
+        recordStatus("iframe-appended");
+
+        const hostConnection = await hostConnectionPromise;
+        recordStatus("host-connected");
+        await childConnectedPromise;
+
+        const guestResult = await hostConnection.remote.guestEcho("parent");
+
+        if (guestResult !== "guest:parent") {
+          throw new Error(\`Unexpected guest result: \${guestResult}\`);
+        }
+
+        iframe.contentWindow.postMessage({ type: "call-host" }, "*");
+        recordStatus("parent-sent-call-host");
+
+        const childResult = await childResultPromise;
+
+        if (childResult !== "host:child") {
+          throw new Error(\`Unexpected child result: \${childResult}\`);
+        }
+
+        hostConnection.close();
+        document.body.dataset.result = "pass";
+        document.body.textContent = "RIMLESS_OPAQUE_ORIGIN_PASS";
+      }
+
+      Promise.race([
+        runTest(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("Timed out waiting for iframe RPC")), 10000)),
+      ]).catch((error) => {
+        document.body.dataset.result = "fail";
+        document.body.textContent = \`RIMLESS_OPAQUE_ORIGIN_FAIL: \${status.join("|")}: \${error?.stack || error}\`;
+      });
+    </script>
+  </body>
+</html>`;
+
+function findChrome() {
+  const candidates = [
+    process.env.CHROME_BIN,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ].filter(Boolean);
+
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getOpenPort() {
+  const server = createServer();
+  const port = await listen(server);
+  await close(server);
+  return port;
+}
+
+async function waitForDebugTarget(debugPort, url) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${debugPort}/json/list`);
+      const targets = await response.json();
+      const target = targets.find((entry) => entry.type === "page" && entry.url === url);
+
+      if (target?.webSocketDebuggerUrl) {
+        return target;
+      }
+    } catch (_error) {
+      // Chrome may need a moment to open the debugging endpoint.
+    }
+
+    await delay(100);
+  }
+
+  throw new Error("Timed out waiting for Chrome debugging target");
+}
+
+function connectToTarget(webSocketDebuggerUrl) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(webSocketDebuggerUrl);
+    const pending = new Map();
+    let nextId = 1;
+
+    socket.addEventListener("open", () => {
+      resolve({
+        close: () => socket.close(),
+        send: (method, params = {}) =>
+          new Promise((sendResolve, sendReject) => {
+            const id = nextId++;
+            pending.set(id, { resolve: sendResolve, reject: sendReject });
+            socket.send(JSON.stringify({ id, method, params }));
+          }),
+      });
+    });
+
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      if (!message.id) return;
+
+      const request = pending.get(message.id);
+      if (!request) return;
+
+      pending.delete(message.id);
+
+      if (message.error) {
+        request.reject(new Error(message.error.message));
+        return;
+      }
+
+      request.resolve(message.result);
+    });
+
+    socket.addEventListener("error", reject);
+  });
+}
+
+function launchChrome(chromePath, debugPort, userDataDir, url) {
+  const browser = spawn(
+    chromePath,
+    [
+      "--headless=new",
+      "--disable-gpu",
+      "--no-sandbox",
+      "--disable-dev-shm-usage",
+      "--no-first-run",
+      `--remote-debugging-port=${debugPort}`,
+      `--user-data-dir=${userDataDir}`,
+      url,
+    ],
+    { stdio: ["ignore", "ignore", "pipe"] },
+  );
+
+  let stderr = "";
+  browser.stderr.setEncoding("utf8");
+  browser.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  return {
+    process: browser,
+    stderr: () => stderr,
+    close: () => {
+      if (!browser.killed) {
+        browser.kill();
+      }
+    },
+  };
+}
+
+const chromePath = findChrome();
+
+if (!chromePath) {
+  console.error("Could not find Chrome or Chromium. Set CHROME_BIN to run the browser integration test.");
+  process.exit(1);
+}
+
+const server = createServer((_request, response) => {
+  response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  response.end(parentHtml);
+});
+
+const port = await listen(server);
+const url = `http://127.0.0.1:${port}/`;
+const debugPort = await getOpenPort();
+const userDataDir = await mkdtemp(path.join(tmpdir(), "rimless-browser-"));
+let browser;
+let target;
+
+try {
+  browser = launchChrome(chromePath, debugPort, userDataDir, url);
+  const debugTarget = await waitForDebugTarget(debugPort, url);
+  target = await connectToTarget(debugTarget.webSocketDebuggerUrl);
+
+  await target.send("Runtime.enable");
+
+  const startedAt = Date.now();
+  let pageState = {};
+
+  while (Date.now() - startedAt < 12000) {
+    const evaluation = await target.send("Runtime.evaluate", {
+      expression:
+        "({ result: document.body.dataset.result || '', status: document.body.dataset.status || '', text: document.body.textContent || '' })",
+      returnByValue: true,
+    });
+
+    pageState = evaluation.result.value;
+
+    if (pageState.result === "pass") {
+      console.log("Opaque-origin iframe browser integration passed in Chrome/Chromium.");
+      process.exitCode = 0;
+      break;
+    }
+
+    if (pageState.result === "fail") {
+      throw new Error(pageState.text);
+    }
+
+    await delay(100);
+  }
+
+  if (pageState.result !== "pass") {
+    throw new Error(`Timed out waiting for browser test result: ${pageState.status || "no status"}`);
+  }
+} finally {
+  target?.close();
+  browser?.close();
+  await rm(userDataDir, { recursive: true, force: true });
+  await close(server);
+}

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractMethods,
   getOriginFromURL,
@@ -7,6 +7,8 @@ import {
   isNodeEnv,
   isServerEnv,
   isWorker,
+  postMessageToTarget,
+  resolveTargetOrigin,
   set,
 } from "../src/helpers";
 
@@ -305,6 +307,49 @@ describe("getOriginFromURL", () => {
   it("handles URLs with default ports", () => {
     expect(getOriginFromURL("http://example.com:80/path")).toBe("http://example.com");
     expect(getOriginFromURL("https://example.com:443/path")).toBe("https://example.com");
+  });
+});
+
+describe("resolveTargetOrigin", () => {
+  it("falls back to wildcard target origin when origin is missing or opaque", () => {
+    expect(resolveTargetOrigin(undefined)).toBe("*");
+    expect(resolveTargetOrigin(null)).toBe("*");
+    expect(resolveTargetOrigin("")).toBe("*");
+    expect(resolveTargetOrigin("null")).toBe("*");
+  });
+
+  it("preserves concrete origins", () => {
+    expect(resolveTargetOrigin("https://example.com")).toBe("https://example.com");
+  });
+});
+
+describe("postMessageToTarget", () => {
+  it("uses wildcard target origin for opaque origins", () => {
+    const target = { postMessage: vi.fn() };
+    const message = { ok: true };
+
+    postMessageToTarget(target as unknown as Window, message, "null");
+
+    expect(target.postMessage).toHaveBeenCalledWith(
+      message,
+      expect.objectContaining({
+        targetOrigin: "*",
+      }),
+    );
+  });
+
+  it("uses concrete target origins when available", () => {
+    const target = { postMessage: vi.fn() };
+    const message = { ok: true };
+
+    postMessageToTarget(target as unknown as Window, message, "https://example.com");
+
+    expect(target.postMessage).toHaveBeenCalledWith(
+      message,
+      expect.objectContaining({
+        targetOrigin: "https://example.com",
+      }),
+    );
   });
 });
 

--- a/tests/opaque-origin-iframe.test.ts
+++ b/tests/opaque-origin-iframe.test.ts
@@ -1,0 +1,148 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as helpers from "../src/helpers";
+import { host } from "../src/index";
+import { actions, events } from "../src/types";
+
+let removeEventListenerSpy: MockInstance<typeof helpers.removeEventListener>;
+let postMessageSpy: MockInstance<typeof helpers.postMessageToTarget>;
+let windowListeners: Map<string, Array<(event: any) => void>>;
+
+beforeEach(() => {
+  windowListeners = new Map();
+
+  vi.spyOn(helpers, "addEventListener").mockImplementation((target, event, handler) => {
+    if (target !== window || typeof handler !== "function") return;
+
+    const handlers = windowListeners.get(event) ?? [];
+    handlers.push(handler as (event: any) => void);
+    windowListeners.set(event, handlers);
+  });
+
+  removeEventListenerSpy = vi.spyOn(helpers, "removeEventListener").mockImplementation((target, event, handler) => {
+    if (target !== window) return;
+
+    const handlers = windowListeners.get(event) ?? [];
+    windowListeners.set(
+      event,
+      handlers.filter((cb) => cb !== handler),
+    );
+  });
+
+  postMessageSpy = vi.spyOn(helpers, "postMessageToTarget").mockImplementation(() => {});
+  vi.spyOn(helpers, "generateId").mockReturnValue("id-1");
+  vi.spyOn(helpers, "isServerEnv").mockReturnValue(false);
+  vi.spyOn(helpers, "isWorkerLike").mockReturnValue(false);
+  vi.spyOn(helpers, "isNodeWorker").mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createMockIframe({ sandbox, src = "https://child.example.com/app" }: { sandbox?: string; src?: string } = {}) {
+  const sandboxTokens = new Set(sandbox?.split(/\s+/).filter(Boolean) ?? []);
+  const contentWindow = { postMessage: vi.fn() };
+
+  return {
+    contentWindow,
+    src,
+    srcdoc: "",
+    hasAttribute: (name: string) => name === "sandbox" && sandbox !== undefined,
+    sandbox: {
+      contains: (token: string) => sandboxTokens.has(token),
+    },
+  } as unknown as HTMLIFrameElement & {
+    contentWindow: Window & { postMessage: ReturnType<typeof vi.fn> };
+  };
+}
+
+function dispatchMessage(event: any) {
+  windowListeners.get(events.MESSAGE)?.forEach((handler) => handler(event));
+}
+
+function createHandshakeRequest(origin: string, source: Window) {
+  return {
+    data: {
+      action: actions.HANDSHAKE_REQUEST,
+      methodNames: [],
+      schema: {},
+    },
+    origin,
+    source,
+  };
+}
+
+function createHandshakeReply(origin: string, source: Window) {
+  return {
+    data: {
+      action: actions.HANDSHAKE_REPLY,
+      connectionID: "id-1",
+    },
+    origin,
+    source,
+  };
+}
+
+describe("opaque-origin iframe handshakes", () => {
+  it("accepts sandboxed opaque iframe messages when the source matches", async () => {
+    const iframe = createMockIframe({ sandbox: "allow-scripts" });
+    const connectionPromise = host.connect(iframe, {});
+
+    dispatchMessage(createHandshakeRequest("null", iframe.contentWindow));
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      iframe.contentWindow,
+      expect.objectContaining({
+        action: actions.HANDSHAKE_REPLY,
+        connectionID: "id-1",
+      }),
+      "null",
+    );
+
+    dispatchMessage(createHandshakeReply("null", iframe.contentWindow));
+
+    const connection = await connectionPromise;
+    connection.close();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(window, events.MESSAGE, expect.any(Function));
+  });
+
+  it("rejects sandboxed opaque iframe messages when the source does not match", () => {
+    const iframe = createMockIframe({ sandbox: "allow-scripts" });
+    const attackerWindow = { postMessage: vi.fn() } as unknown as Window;
+
+    host.connect(iframe, {});
+
+    dispatchMessage(createHandshakeRequest("null", attackerWindow));
+
+    expect(postMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps normal iframe validation strict by requiring matching origin and source", async () => {
+    const iframe = createMockIframe();
+    const attackerWindow = { postMessage: vi.fn() } as unknown as Window;
+    const connectionPromise = host.connect(iframe, {});
+
+    dispatchMessage(createHandshakeRequest("https://child.example.com", attackerWindow));
+    dispatchMessage(createHandshakeRequest("https://attacker.example.com", iframe.contentWindow));
+
+    expect(postMessageSpy).not.toHaveBeenCalled();
+
+    dispatchMessage(createHandshakeRequest("https://child.example.com", iframe.contentWindow));
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      iframe.contentWindow,
+      expect.objectContaining({
+        action: actions.HANDSHAKE_REPLY,
+        connectionID: "id-1",
+      }),
+      "https://child.example.com",
+    );
+
+    dispatchMessage(createHandshakeReply("https://child.example.com", iframe.contentWindow));
+
+    const connection = await connectionPromise;
+    connection.close();
+  });
+});


### PR DESCRIPTION
## What changed

- Accept sandboxed iframe handshake messages with opaque `"null"` origins when the message source matches the target iframe.
- Resolve opaque or missing target origins to `*` before calling `postMessage`.
- Add focused unit regression coverage and a Chrome/Chromium browser integration script for the opaque-origin iframe flow.

## Why

Sandboxed iframes without `allow-same-origin` emit messages with an opaque `"null"` origin. The host previously required the event origin to match the iframe URL origin, so valid sandboxed iframe handshakes were rejected.

## Validation

- `npm test -- tests/helpers.test.ts tests/opaque-origin-iframe.test.ts`
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run test:browser`