### PR TITLE
fix: support npm trusted publishing

### DIFF
--- a/.changeset/tidy-release-publishing.md
+++ b/.changeset/tidy-release-publishing.md
@@ -1,0 +1,5 @@
+---
+"rimless": patch
+---
+
+Fix the release workflow for npm trusted publishing and keep package scripts aligned with Bun.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
@@ -48,4 +48,3 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Docs and runnable examples live in `docs/` and are served through Storybook.
 - Tests currently live in `tests/` and run with Vitest using `happy-dom`.
 - Build output is generated into `lib/`. Do not edit generated `lib/` files directly.
-- Use `npm` for project commands. `package-lock.json` is committed and CI uses `npm ci`.
+- Use `bun` for project commands. `bun.lock` is committed and CI uses `bun install --frozen-lockfile`.
 - Do not introduce another package manager unless the task is an explicit package-manager migration.
 
 # Required Workflow
@@ -25,27 +25,27 @@ Bug fixes must reproduce the issue before fixing it and must add or update a reg
 For code changes, run the focused test first, then the full validation set before finishing:
 
 ```sh
-npm test
-npm run lint
-npm run build
+bun run test
+bun run lint
+bun run build
 ```
 
 If dependencies are missing in a fresh checkout, run:
 
 ```sh
-npm ci
+bun install --frozen-lockfile
 ```
 
 Documentation-only changes do not require the full validation set.
 
 # Common Commands
 
-- `npm test` - run all Vitest tests.
-- `npm run test:coverage` - run tests with coverage thresholds.
-- `npm run lint` - run ESLint.
-- `npm run build` - typecheck source and tests, then build the library with Vite.
-- `npm run storybook` - start Storybook for docs/examples.
-- `npm run build-storybook` - build Storybook.
+- `bun run test` - run all Vitest tests.
+- `bun run test:coverage` - run tests with coverage thresholds.
+- `bun run lint` - run ESLint.
+- `bun run build` - typecheck source and tests, then build the library with Vite.
+- `bun run storybook` - start Storybook for docs/examples.
+- `bun run build-storybook` - build Storybook.
 
 # Coding Rules
 
@@ -78,8 +78,8 @@ Documentation-only changes do not require the full validation set.
 
 # Generated And Packaged Artifacts
 
-- Do not edit `lib/` directly. Update `src/`, then run `npm run build`.
-- If dependencies change, update `package-lock.json` through npm commands rather than manual edits.
+- Do not edit `lib/` directly. Update `src/`, then run `bun run build`.
+- If dependencies change, update `bun.lock` through Bun commands rather than manual edits.
 - Do not manually edit `package.json` versions as part of routine code changes.
 
 # Git

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format:check": "biome check .",
     "lint": "biome lint .",
     "test": "vitest run",
-    "test:browser": "npm run build && node tests/browser/opaque-origin-iframe.mjs",
+    "test:browser": "bun run build && node tests/browser/opaque-origin-iframe.mjs",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/au-re/rimless.git"
+    "url": "git+https://github.com/au-re/rimless.git"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",


### PR DESCRIPTION
## Summary

- update the release workflow to use Node 24 for npm trusted publishing while keeping Bun-based Changesets commands
- remove the unused NODE_AUTH_TOKEN wiring for tokenless OIDC publishing
- align AGENTS.md and the browser test script with the Bun workflow
- add a patch Changesets entry for the release publishing fix

## Root Cause

The release job had no NPM_TOKEN, so Changesets used npm trusted publishing through OIDC. That path depends on newer npm support, while the workflow was running on Node 22. The workflow now uses Node 24 for the publish environment without switching package-manager commands away from Bun.

## Validation

- `bun install --frozen-lockfile`
- `bun run test`
- `bun run lint`
- `bun run build`
- `bun run test:browser`