### PR TITLE
fix: restore published TypeScript declarations

### DIFF
--- a/.changeset/restore-published-types.md
+++ b/.changeset/restore-published-types.md
@@ -1,0 +1,5 @@
+---
+"rimless": patch
+---
+
+Restore the published TypeScript declarations. The 0.8.x series advertised `lib/index.d.ts` in `package.json` but the file was missing from the tarball: `vite-plugin-dts` v5 dropped the singular `outDir` option, so dts files were silently emitted to `dist/` instead of `lib/`. The vite build now sets `build.outDir: "lib"` as the single source of truth and uses `entryRoot: "src"` so declarations land directly under `lib/` (e.g. `lib/index.d.ts`, `lib/guest.d.ts`), matching the layout shipped before 0.8.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,9 @@ import dts from "vite-plugin-dts";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [dts({ insertTypesEntry: true, outDir: "lib", include: ["src"] })],
+  plugins: [dts({ insertTypesEntry: true, include: ["src"], entryRoot: "src" })],
   build: {
+    outDir: "lib",
     lib: {
       entry: path.resolve(__dirname, "src/index.ts"),
       name: "rimless",
@@ -14,9 +15,6 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [],
-      output: {
-        dir: "lib",
-      },
     },
     sourcemap: true,
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- The 0.8.x tarballs advertise `"types": "lib/index.d.ts"` in `package.json` but do not actually include the file, so consumers have been adding local ambient shims to keep strict typecheck green.
- Root cause: in #104 (`vite-plugin-dts` 3 → 5) the plugin's singular `outDir` option was silently dropped in favor of `outDirs`. With the old key ignored, `unplugin-dts` fell back to vite's `build.outDir` default (`dist`), while `rollupOptions.output.dir` was overriding the JS bundles to `lib`. The two configs disagreed silently and the dts plugin dropped the entry with `[unplugin:dts] Outside emitted: …/lib/index.d.ts`.
- Make `build.outDir: "lib"` the single source of truth, drop the redundant `rollupOptions.output.dir` override, and set `entryRoot: "src"` so declarations land directly under `lib/` (matching the layout shipped pre-0.8) instead of `lib/src/` behind a re-export shim.

## Test plan
- [x] `bun run validate` (format, lint, build, 51 tests) passes locally.
- [x] No `[unplugin:dts] Outside emitted` warning during `bun run build`.
- [x] `npm pack --dry-run` lists `lib/index.d.ts`, `lib/guest.d.ts`, `lib/host.d.ts`, `lib/helpers.d.ts`, `lib/rpc.d.ts`, `lib/types.d.ts` alongside the JS bundles